### PR TITLE
Close log so we don't keep files open

### DIFF
--- a/wirelog/wirelog.go
+++ b/wirelog/wirelog.go
@@ -113,3 +113,8 @@ func (c *Conn) Write(b []byte) (n int, err error) {
 	c.log.Write(b[0:write])
 	return write, err
 }
+
+func (c *Conn) Close() error {
+	c.log.Close()
+	return c.Conn.Close()
+}


### PR DESCRIPTION
When using LogToFile it opens the file, and it will never be closed. This will close the file, or whatever WriteCloser is given.